### PR TITLE
Added ClipBoard Icon (fa-lg)

### DIFF
--- a/src/components/AnimePlayer.vue
+++ b/src/components/AnimePlayer.vue
@@ -89,6 +89,7 @@
                         break-all
                         select-all
                         cursor-pointer
+                        fa fa-clipboard fa-lg
                     "
                     @click.stop.prevent="
                         !!void (
@@ -96,7 +97,7 @@
                             copyToClipboard(currentPlaying.url)
                         )
                     "
-                    >{{ shrinkText(currentPlaying.url) }}</span
+                    >{{ shrinkText(currentPlaying.url) }} </span
                 >
             </p>
         </div>


### PR DESCRIPTION
Clipboard icon added to Span Class list (at the bottom)
Icon size is also is `fa-lg` as it says on the fontawesome website