### PR TITLE
feat: show loading when player is buffering

### DIFF
--- a/lib/core/models/player.dart
+++ b/lib/core/models/player.dart
@@ -6,6 +6,7 @@ enum PlayerEvents {
   durationUpdate,
   play,
   pause,
+  buffering,
   seek,
   volume,
   end,
@@ -51,6 +52,7 @@ abstract class Player extends Eventer<PlayerEvent> {
   }
 
   bool get isPlaying;
+  bool get isBuffering;
   Duration? get duration;
   Duration? get totalDuration;
   int get volume;

--- a/lib/pages/anime_page/watch_page.dart
+++ b/lib/pages/anime_page/watch_page.dart
@@ -1,13 +1,16 @@
 import 'dart:async';
 import 'dart:convert';
+
 import 'package:extensions/extensions.dart' as extensions;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+
 import './select_source.dart';
 import '../../config.dart';
 import '../../core/models/player.dart' as player_model;
 import '../../core/models/tracker_provider.dart';
 import '../../core/trackers/providers.dart';
+import '../../plugins/helpers/double_value_listenable_builder.dart';
 import '../../plugins/helpers/screen.dart';
 import '../../plugins/helpers/stateful_holder.dart';
 import '../../plugins/helpers/ui.dart';
@@ -77,6 +80,7 @@ class WatchPageState extends State<WatchPage>
   final Duration animationDuration = const Duration(milliseconds: 300);
 
   final ValueNotifier<bool> isPlaying = ValueNotifier<bool>(false);
+  final ValueNotifier<bool> isBuffering = ValueNotifier<bool>(true);
   late AnimationController playPauseController;
   late AnimationController overlayController;
 
@@ -260,6 +264,10 @@ class WatchPageState extends State<WatchPage>
 
       case player_model.PlayerEvents.speed:
         speed = player!.speed;
+        break;
+
+      case player_model.PlayerEvents.buffering:
+        isBuffering.value = player!.isBuffering;
         break;
 
       case player_model.PlayerEvents.error:
@@ -667,19 +675,28 @@ class WatchPageState extends State<WatchPage>
                                                       color: Colors.white,
                                                     ),
                                                   ),
-                                                  ValueListenableBuilder<bool>(
-                                                    valueListenable: isPlaying,
+                                                  DoubleValueListenableBuilder<
+                                                      bool, bool>(
+                                                    valueListenable1: isPlaying,
+                                                    valueListenable2:
+                                                        isBuffering,
                                                     builder: (
                                                       final BuildContext
                                                           context,
                                                       final bool isPlaying,
+                                                      final bool isBuffering,
                                                       final Widget? child,
                                                     ) {
-                                                      isPlaying
-                                                          ? playPauseController
-                                                              .forward()
-                                                          : playPauseController
-                                                              .reverse();
+                                                      if (isBuffering &&
+                                                          isPlaying) {
+                                                        return loader;
+                                                      } else {
+                                                        isPlaying
+                                                            ? playPauseController
+                                                                .forward()
+                                                            : playPauseController
+                                                                .reverse();
+                                                      }
                                                       return Material(
                                                         type: MaterialType
                                                             .transparency,

--- a/lib/plugins/helpers/double_value_listenable_builder.dart
+++ b/lib/plugins/helpers/double_value_listenable_builder.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+typedef DoubleValueWidgetBuilder<T, T2> = Widget Function(
+  BuildContext context,
+  T value1,
+  T2 value2,
+  Widget? child,
+);
+
+class DoubleValueListenableBuilder<T, T2> extends StatefulWidget {
+  const DoubleValueListenableBuilder({
+    required final this.valueListenable1,
+    required final this.valueListenable2,
+    required final this.builder,
+    final this.child,
+    final Key? key,
+  }) : super(key: key);
+
+  final ValueListenable<T> valueListenable1;
+  final ValueListenable<T2> valueListenable2;
+  final DoubleValueWidgetBuilder<T, T2> builder;
+  final Widget? child;
+
+  @override
+  State<StatefulWidget> createState() =>
+      _DoubleValueListenableBuilderState<T, T2>();
+}
+
+class _DoubleValueListenableBuilderState<T, T2>
+    extends State<DoubleValueListenableBuilder<T, T2>> {
+  late T value1;
+  late T2 value2;
+
+  @override
+  void initState() {
+    super.initState();
+    value1 = widget.valueListenable1.value;
+    value2 = widget.valueListenable2.value;
+    widget.valueListenable1.addListener(_valueChanged1);
+    widget.valueListenable2.addListener(_valueChanged2);
+  }
+
+  @override
+  void didUpdateWidget(final DoubleValueListenableBuilder<T, T2> oldWidget) {
+    if (oldWidget.valueListenable1 != widget.valueListenable1 &&
+        oldWidget.valueListenable2 != widget.valueListenable2) {
+      oldWidget.valueListenable1.removeListener(_valueChanged1);
+      value1 = widget.valueListenable1.value;
+      widget.valueListenable1.addListener(_valueChanged1);
+
+      oldWidget.valueListenable2.removeListener(_valueChanged2);
+      value2 = widget.valueListenable2.value;
+      widget.valueListenable2.addListener(_valueChanged2);
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  void dispose() {
+    widget.valueListenable1.removeListener(_valueChanged1);
+    widget.valueListenable2.removeListener(_valueChanged2);
+    super.dispose();
+  }
+
+  void _valueChanged1() {
+    setState(() {
+      value1 = widget.valueListenable1.value;
+    });
+  }
+
+  void _valueChanged2() {
+    setState(() {
+      value2 = widget.valueListenable2.value;
+    });
+  }
+
+  @override
+  Widget build(final BuildContext context) =>
+      widget.builder(context, value1, value2, widget.child);
+}

--- a/lib/plugins/translator/translations/pt_br.dart
+++ b/lib/plugins/translator/translations/pt_br.dart
@@ -332,7 +332,7 @@ class Sentences extends en.Sentences {
   String topAnimes() => 'Top Animes';
 
   @override
-  String recentlyUpdated() => 'Atualizado recentemente';
+  String recentlyUpdated() => 'Atualizados recentemente';
 
   @override
   String recommendedBy(final String by) => 'Recomendado por $by';

--- a/lib/plugins/video_player/better_player.dart
+++ b/lib/plugins/video_player/better_player.dart
@@ -71,6 +71,10 @@ class BetterPlayer extends model.Player {
               dispatch(model.PlayerEvent(model.PlayerEvents.speed, null));
               break;
 
+            case better_player.BetterPlayerEventType.bufferingUpdate:
+              dispatch(model.PlayerEvent(model.PlayerEvents.buffering, null));
+              break;
+
             case better_player.BetterPlayerEventType.exception:
               dispatch(
                 model.PlayerEvent(model.PlayerEvents.error, e.parameters),
@@ -122,6 +126,9 @@ class BetterPlayer extends model.Player {
 
   @override
   bool get isPlaying => _controller.isPlaying() ?? false;
+
+  @override
+  bool get isBuffering => _controller.isBuffering() ?? true;
 
   @override
   Duration? get duration => _controller.videoPlayerController?.value.position;

--- a/lib/plugins/video_player/dart_vlc.dart
+++ b/lib/plugins/video_player/dart_vlc.dart
@@ -14,6 +14,7 @@ class DartVlc extends model.Player {
 
   double? _prevSpeed;
   double? _prevVolume;
+  double? _prevBuffering;
   final GlobalKey _playerKey = GlobalKey();
 
   final List<StreamSubscription<dynamic>> _subscriptions =
@@ -55,6 +56,12 @@ class DartVlc extends model.Player {
             ready = true;
           }
         }),
+        _player.bufferingProgressStream
+            .listen((final double bufferingProgress) {
+          if (_prevBuffering != bufferingProgress) {
+            dispatch(model.PlayerEvent(model.PlayerEvents.buffering, null));
+          }
+        })
       ],
     );
 
@@ -115,6 +122,9 @@ class DartVlc extends model.Player {
 
   @override
   bool get isPlaying => _player.playback.isPlaying;
+
+  @override
+  bool get isBuffering => _player.bufferingProgress < 100.0;
 
   @override
   Duration? get duration => _player.position.position;


### PR DESCRIPTION
Hey @zyrouge !

This PR adds:
- Video buffering detection to show user when it's loading
- A new `ValueListenableBuilder`  widget capable of listening 2 values
- One updated string for `pt_br` translation

Btw, I had some issues with recent translations changes but I managed to fix it for running locally (I am not pushing these translation changes since I just wanted to check this buffering feature). Maybe we could use [intl](https://pub.dev/packages/intl) to facilitate things a little bit?

Let me know what you think.
Thank you!

