### PR TITLE
feat: preload adjacent pages on manga page reader

### DIFF
--- a/lib/pages/manga_page/page_reader.dart
+++ b/lib/pages/manga_page/page_reader.dart
@@ -373,6 +373,7 @@ class _PageReaderState extends State<PageReader>
                   }
                 },
                 child: PageView.builder(
+                  allowImplicitScrolling: true,
                   scrollDirection:
                       AppState.settings.current.mangaReaderSwipeDirection ==
                               MangaSwipeDirections.horizontal


### PR DESCRIPTION
In current version, all pages will quickly show the loading indicator, `allowImplicitScrolling: true` preloads the previous and next page in `PageView` ([Reference](https://github.com/flutter/flutter/issues/31191#issuecomment-828176688)).